### PR TITLE
Make the user parameter optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See also
 Installation
 ------------
 
-    curl https://raw.githubusercontent.com/Leryan/ansible-dconf/master/dconf.py > ~/ansible_dir/library/dconf
+    curl https://raw.githubusercontent.com/jistr/ansible-dconf/master/dconf.py > ~/ansible_dir/library/dconf
 
 Usage examples
 --------------
@@ -20,7 +20,7 @@ Usage examples
         key: '/org/gnome/terminal/legacy/default-show-menubar'
         value: 'false'
 
-The `user` parameter is optional, using the currently connected user. If set, it uses `su - <user>` to switch.
+The `user` parameter is optional, using the currently connected user if omitted. If set, it uses `su - <user>` to switch.
 
 Be careful with string values, which should be passed into DConf
 single-quoted. You'll need to quote the value twice in YAML:

--- a/README.md
+++ b/README.md
@@ -9,20 +9,24 @@ See also
 Installation
 ------------
 
-    curl https://raw.github.com/jistr/ansible-dconf/master/dconf.py > ~/ansible_dir/library/dconf
+    curl https://raw.githubusercontent.com/Leryan/ansible-dconf/master/dconf.py > ~/ansible_dir/library/dconf
 
 Usage examples
 --------------
 
     - name: gnome-terminal default-show-menubar
-      dconf: user=jistr
-             key=/org/gnome/terminal/legacy/default-show-menubar
-             value=false
+      dconf:
+        user: 'jistr'
+        key: '/org/gnome/terminal/legacy/default-show-menubar'
+        value: 'false'
+
+The `user` parameter is optional, using the currently connected user. If set, it uses `su - <user>` to switch.
 
 Be careful with string values, which should be passed into DConf
 single-quoted. You'll need to quote the value twice in YAML:
 
     - name: shortcut help
-      dconf: user=jistr
-             key=/org/gnome/terminal/legacy/keybindings/help
-             value="'disabled'"
+      dconf:
+        user: 'jistr'
+        key: '/org/gnome/terminal/legacy/keybindings/help'
+        value: "'disabled'"

--- a/dconf.py
+++ b/dconf.py
@@ -19,6 +19,9 @@ def _set_value(user, key, value):
         'kill $DBUS_SESSION_BUS_PID &> /dev/null'
     ])
 
+    if user is None:
+        return subprocess.check_output(['/bin/sh', '-c', command]).strip()
+
     return subprocess.check_output([
         'su', '-', user , '-c', command
     ]).strip()
@@ -33,6 +36,9 @@ def _get_value(user, key):
         'kill $DBUS_SESSION_BUS_PID &> /dev/null'
     ])
 
+    if user is None:
+        return subprocess.check_output(['/bin/sh', '-c', command]).strip()
+
     return subprocess.check_output([
         'su', '-', user , '-c', command
     ]).strip()
@@ -42,7 +48,7 @@ def main():
     module = AnsibleModule(
         argument_spec = {
             'state': { 'choices': ['present'], 'default': 'present' },
-            'user': { 'required': True },
+            'user': { 'default': None },
             'key': { 'required': True },
             'value': { 'required': True },
         },


### PR DESCRIPTION
If given, stay with the default behavior (su - <user> -c cmd), otherwise use the
currently loged-in user.

Also update the README.